### PR TITLE
Support closing chdb connection

### DIFF
--- a/clickhouse_sqlalchemy/drivers/chdb/base.py
+++ b/clickhouse_sqlalchemy/drivers/chdb/base.py
@@ -34,7 +34,7 @@ class ClickHouseDialect_chdb(ClickHouseDialect):
 
     @classmethod
     def get_pool_class(cls, url):
-        return pool.SingletonThreadPool
+        return pool.NullPool
 
     def _get_server_version_info(self, connection):
         return tuple(int(x) for x in self._execute(connection, "SELECT version()", scalar=True).split("."))

--- a/clickhouse_sqlalchemy/drivers/chdb/connector.py
+++ b/clickhouse_sqlalchemy/drivers/chdb/connector.py
@@ -32,7 +32,7 @@ class Connection(object):
         super(Connection, self).__init__()
 
     def close(self):
-        pass
+        self._connection.close()
 
     def commit(self):
         pass


### PR DESCRIPTION
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes https://github.com/chdb-io/chdb/issues/213

Supports statements like `with engine.connect() as conn:` to automatically close the chdb connection.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [ ] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
